### PR TITLE
Triggered Submission named and info text

### DIFF
--- a/src/components/exercise/VersionList.js
+++ b/src/components/exercise/VersionList.js
@@ -103,8 +103,8 @@ class VersionList extends Component {
     createSubmissionItem(item, index, isSubmit){
         const active = item.id === this.props.selectedSubmissionId;
         const outdated = item.invalid;
-        const title = (isSubmit ? 'Submission ' : 'Testrun ') + (index + 1); 
-
+        const triggeredReSubmission = item.triggeredReSubmission;
+        const title = (triggeredReSubmission? 'Generated Submission' : (isSubmit ? 'Submission ' : 'Testrun ') + (index + 1) );
 
         const ret_item = (
             <li key={item.id} className={ active ? 'active' : ''}>

--- a/src/components/exercise/VersionList.js
+++ b/src/components/exercise/VersionList.js
@@ -35,7 +35,7 @@ class VersionList extends Component {
         this.setShowModal(false);
         this.props.submit(true, this.resetSubmitButton);
         this.setState({submissionState: true});
-    }
+    };
 
     resetSubmitButton = () => {
         this.setState({submissionState: false});
@@ -43,7 +43,7 @@ class VersionList extends Component {
 
     setCurrentTab = (key) => {
         this.setState({currentTab: key});
-    }
+    };
 
     componentDidMount = async () => {
         const {exercise} = this.props;
@@ -80,7 +80,7 @@ class VersionList extends Component {
             </Alert>))[0] : '';
         const alert = outdated ? <Alert variant="danger">This submission is outdated!</Alert> : '';
         const triggered = triggeredReSubmission ?
-            <Alert variant="primary">This is an automatically triggered Submission by the System</Alert> : '';
+            <Alert variant="primary">This is an automatically triggered submission by the system</Alert> : '';
         let score = 'No Score';
         if (result) {
             score = <>
@@ -144,7 +144,7 @@ class VersionList extends Component {
 
     setShowModal = (show) => {
         this.setState({showModal: show});
-    }
+    };
 
     lastSubmissionWarning() {
         const {showModal} = this.state;

--- a/src/components/exercise/VersionList.js
+++ b/src/components/exercise/VersionList.js
@@ -1,10 +1,10 @@
 import SubmissionService from '../../utils/SubmissionService';
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 
 import equal from 'fast-deep-equal';
 import Util from '../../utils/Util';
-import { OverlayTrigger, Popover, Tabs, Tab, Modal, Alert } from 'react-bootstrap';
-import { Send, RotateCcw, X, Flag, Info } from 'react-feather';
+import {OverlayTrigger, Popover, Tabs, Tab, Modal, Alert} from 'react-bootstrap';
+import {Send, RotateCcw, X, Flag, Info} from 'react-feather';
 import PropTypes from 'prop-types';
 import Spinner from '../core/Spinner';
 import './VersionList.css';
@@ -24,9 +24,9 @@ class VersionList extends Component {
     };
 
     onSubmit = () => {
-        if(this.state.submissionCount.submissionsRemaining <= 1){
+        if (this.state.submissionCount.submissionsRemaining <= 1) {
             this.setShowModal(true);
-        }else{
+        } else {
             this.confirmSubmit();
         }
     };
@@ -34,11 +34,11 @@ class VersionList extends Component {
     confirmSubmit = () => {
         this.setShowModal(false);
         this.props.submit(true, this.resetSubmitButton);
-        this.setState({ submissionState: true });
+        this.setState({submissionState: true});
     }
 
     resetSubmitButton = () => {
-        this.setState({ submissionState: false });
+        this.setState({submissionState: false});
     };
 
     setCurrentTab = (key) => {
@@ -46,14 +46,14 @@ class VersionList extends Component {
     }
 
     componentDidMount = async () => {
-        const { exercise } = this.props;
+        const {exercise} = this.props;
 
         this.fetchSubmissions(exercise.id);
         this.setCurrentTab(this.props.isGraded ? 'submits' : 'testruns');
     };
 
     componentDidUpdate = async (prevProps) => {
-        const { exercise, selectedSubmissionId } = this.props;
+        const {exercise, selectedSubmissionId} = this.props;
         if (!equal(exercise, prevProps.exercise) || !equal(selectedSubmissionId, prevProps.selectedSubmissionId)) {
             this.fetchSubmissions(exercise.id);
             this.setCurrentTab(this.props.isGraded ? 'submits' : 'testruns');
@@ -61,38 +61,41 @@ class VersionList extends Component {
     };
 
     fetchSubmissions = async (exerciseId) => {
-        const { authorizationHeader } = this.props;
+        const {authorizationHeader} = this.props;
         const {submissions, runs, submissionCount, pastDueDate} = await SubmissionService.getSubmissionList(exerciseId, authorizationHeader);
-        
-        this.setState({ 
+
+        this.setState({
             submissions,
             runs,
             pastDueDate,
             submissionCount: submissionCount
-         });
+        });
     };
 
-    createPopover(version, result, hints, outdated) {
-        const hintlist = hints ? (hints.map((hint, index) => 
+    createPopover(version, result, hints, outdated, triggeredReSubmission) {
+        const hintlist = hints ? (hints.map((hint, index) =>
             <Alert key={index} variant="warning">
-                <Flag size={14} /> Hint<br />
+                <Flag size={14}/> Hint<br/>
                 {hint}
             </Alert>))[0] : '';
         const alert = outdated ? <Alert variant="danger">This submission is outdated!</Alert> : '';
+        const triggered = triggeredReSubmission ?
+            <Alert variant="primary">This is an automatically triggered Submission by the System</Alert> : '';
         let score = 'No Score';
-        if(result){
+        if (result) {
             score = <>
-            Your Score: {result.score}
-            <br />
-            Max Points: {result.maxScore}
+                Your Score: {result.score}
+                <br/>
+                Max Points: {result.maxScore}
             </>
         }
 
         return (
             <Popover id="popover-basic">
-                <Popover.Title>{'Submission ' + version}</Popover.Title>
+                <Popover.Title>{triggeredReSubmission ? 'Automatic Submission' : 'Submission ' + version}</Popover.Title>
                 <Popover.Content>
                     {alert}
+                    {triggered}
                     <pre>{score}</pre>
                     {hintlist}
                 </Popover.Content>
@@ -100,16 +103,18 @@ class VersionList extends Component {
         );
     }
 
-    createSubmissionItem(item, index, isSubmit){
+    createSubmissionItem(item, index, isSubmit) {
         const active = item.id === this.props.selectedSubmissionId;
         const outdated = item.invalid;
         const triggeredReSubmission = item.triggeredReSubmission;
-        const title = (triggeredReSubmission? 'Generated Submission' : (isSubmit ? 'Submission ' : 'Testrun ') + (index + 1) );
+        const title = (triggeredReSubmission ? 'Automatic Submission' : (isSubmit ? 'Submission ' : 'Testrun ') + (index + 1));
+
+        console.log(item);
 
         const ret_item = (
-            <li key={item.id} className={ active ? 'active' : ''}>
+            <li key={item.id} className={active ? 'active' : ''}>
                 <div id={item.id}
-                        className={'submission-item ' + (outdated ? 'outdated' : '')}>
+                     className={'submission-item ' + (outdated ? 'outdated' : '')}>
                     <strong>{title}{item.result && <span className="float-right">({item.result.score}P)</span>}</strong>
                     <br/>
                     <small>{Util.timeFormatter(item.timestamp)}</small>
@@ -118,15 +123,15 @@ class VersionList extends Component {
                         <button
                             className={'style-btn ' + (outdated ? 'warn' : '')}
                             onClick={this.props.changeSubmissionById.bind(this, item.id)}>
-                                <RotateCcw size={14} />Load
+                            <RotateCcw size={14}/>Load
                         </button>
                         <span className="p-1"></span>
-                        {isSubmit && 
+                        {isSubmit &&
                         <OverlayTrigger trigger="click"
                                         rootClose={true}
                                         placement="top"
-                                        overlay={this.createPopover((index + 1), item.result, item.result ? item.result.hints : [], outdated)}>
-                            <button className="style-btn ghost"><Info size={14} />Info</button>
+                                        overlay={this.createPopover((index + 1), item.result, item.result ? item.result.hints : [], outdated, triggeredReSubmission)}>
+                            <button className="style-btn ghost"><Info size={14}/>Info</button>
                         </OverlayTrigger>
                         }
                     </div>
@@ -134,7 +139,7 @@ class VersionList extends Component {
             </li>
         );
 
-        return(ret_item);
+        return (ret_item);
     }
 
     setShowModal = (show) => {
@@ -142,51 +147,51 @@ class VersionList extends Component {
     }
 
     lastSubmissionWarning() {
-        const { showModal} = this.state;
-      
+        const {showModal} = this.state;
+
         return (
-          <>
-            <Modal centered show={showModal} onHide={this.setShowModal.bind(this, false)}>
-              <Modal.Header closeButton>
-                <Modal.Title>Last Submission</Modal.Title>
-              </Modal.Header>
-              <Modal.Body>This is you last submission for this task. Are you sure you want to submit?</Modal.Body>
-              <Modal.Footer>
-                <button className="style-btn" onClick={this.setShowModal.bind(this, false)}>
-                  <X size={14} /> Close
-                </button>
-                <button className="style-btn submit" onClick={this.confirmSubmit}>
-                  <Send size={14} /> Submit
-                </button>
-              </Modal.Footer>
-            </Modal>
-          </>
+            <>
+                <Modal centered show={showModal} onHide={this.setShowModal.bind(this, false)}>
+                    <Modal.Header closeButton>
+                        <Modal.Title>Last Submission</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>This is you last submission for this task. Are you sure you want to submit?</Modal.Body>
+                    <Modal.Footer>
+                        <button className="style-btn" onClick={this.setShowModal.bind(this, false)}>
+                            <X size={14}/> Close
+                        </button>
+                        <button className="style-btn submit" onClick={this.confirmSubmit}>
+                            <Send size={14}/> Submit
+                        </button>
+                    </Modal.Footer>
+                </Modal>
+            </>
         );
     }
-    
+
 
     render() {
         const submissions = this.state.submissions || [];
         const runs = this.state.runs || [];
-        const {isCodeType, exercise } = this.props;
+        const {isCodeType, exercise} = this.props;
         const score = submissions.length && submissions[0] && submissions[0].result && submissions[0].result.score ? submissions[0].result.score : 0;
         const maxScore = exercise.maxScore ? exercise.maxScore : 1;
         const scorePercent = (score / maxScore * 100);
-        
+
         let scoreProgress = "low";
-        
-        if(scorePercent > 75) {
+
+        if (scorePercent > 75) {
             scoreProgress = "full";
-        }else if(scorePercent >= 50) {
+        } else if (scorePercent >= 50) {
             scoreProgress = "mid";
         }
 
 
         let submitButtonContent;
         if (this.state.submissionState)
-            submitButtonContent = <Spinner text={'Submitting'} />;
+            submitButtonContent = <Spinner text={'Submitting'}/>;
         else
-            submitButtonContent = <><Send size={14} />Submit</>;
+            submitButtonContent = <><Send size={14}/>Submit</>;
 
         const templatePart = (
             <li>
@@ -196,7 +201,7 @@ class VersionList extends Component {
                     <div className="two-box">
                         <button className="style-btn"
                                 onClick={this.props.changeSubmissionById.bind(this, -1)}>
-                                    <RotateCcw size={14} />Reset
+                            <RotateCcw size={14}/>Reset
                         </button>
                     </div>
                 </div>
@@ -206,30 +211,30 @@ class VersionList extends Component {
         return (
             <div id={'version-wrapper'}>
                 {this.lastSubmissionWarning()}
-                
-                <span className="score-board" >
+
+                <span className="score-board">
                     <span>Score: <strong>{score}</strong> / {maxScore}</span>
                     <span className={"score-bar " + scoreProgress} style={{
-                            width: scorePercent + "%"
-                        }}>
+                        width: scorePercent + "%"
+                    }}>
                     </span>
                 </span>
 
-                {!this.state.pastDueDate && 
-                    <>
-                        <button className="style-btn submit full"
-                                    disabled={this.state.submissionState || this.state.submissionCount.submissionsRemaining <= 0}
-                                    onClick={this.onSubmit}>{submitButtonContent}</button>
-                        <div className="text-center mt-1">
-                            <small>
-                                <strong>{this.state.submissionCount.submissionsRemaining}</strong> Submissions available
-                            </small>
-                        </div>
-                        <br/>
-                    </>
+                {!this.state.pastDueDate &&
+                <>
+                    <button className="style-btn submit full"
+                            disabled={this.state.submissionState || this.state.submissionCount.submissionsRemaining <= 0}
+                            onClick={this.onSubmit}>{submitButtonContent}</button>
+                    <div className="text-center mt-1">
+                        <small>
+                            <strong>{this.state.submissionCount.submissionsRemaining}</strong> Submissions available
+                        </small>
+                    </div>
+                    <br/>
+                </>
                 }
 
-                {isCodeType ? 
+                {isCodeType ?
                     <Tabs activeKey={this.state.currentTab} id="submit-test-tab" onSelect={this.setCurrentTab}>
                         <Tab eventKey="testruns" title="Testruns">
                             {runs.length === 0 ? <div className="py-3">No runs</div> : ''}
@@ -238,7 +243,7 @@ class VersionList extends Component {
                                 {templatePart}
                             </ul>
                         </Tab>
-                        <Tab eventKey="submits" title="Submits" >
+                        <Tab eventKey="submits" title="Submits">
                             {submissions.length === 0 ? <div className="py-3">No submissions</div> : ''}
                             <ul className="style-list">
                                 {submissions.map((item, index) => this.createSubmissionItem(item, (submissions.length - index - 1), true),)}
@@ -246,7 +251,7 @@ class VersionList extends Component {
                             </ul>
                         </Tab>
                     </Tabs>
-                :
+                    :
                     <>
                         <h4>Submissions</h4>
                         <p>{submissions.length === 0 ? 'No submissions' : ''}</p>
@@ -257,7 +262,7 @@ class VersionList extends Component {
                     </>
                 }
 
-                
+
             </div>
         );
     }


### PR DESCRIPTION
This pull requests adds that triggered Submissions will be displayed as Automatic Submission and will show a little text in the Info-popup that explains to the user that this submission was automatically triggered by the system.
This also needs the 'triggered-submissions-#311' branch to be included in the Backend since otherwise it does not send the 'triggeredReSubmission' flag to the frontend.