### PR TITLE
Show more detailed date time info

### DIFF
--- a/src/components/AssignmentList.js
+++ b/src/components/AssignmentList.js
@@ -2,29 +2,43 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import Util from '../utils/Util';
 import PropTypes from 'prop-types';
-import { Lock, Clock } from 'react-feather';
+import { Clock, Lock } from 'react-feather';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 const AssignmentList = ({ courseId, assignments, isAssistant, onAssignmentExportClick, results }) => {
     const listItems = assignments.map((assignment, index) => {
-            const pastDueDate = new Date(assignment.dueDate) < (new Date());
+            const pastDueDate = assignment.pastDueDate;
             const label = <><h5>{assignment.title}</h5></>;
-            const result = results ? results.find(r => r.assignmentId === assignment.id): undefined;
+            const result = results ? results.find(r => r.assignmentId === assignment.id) : undefined;
+            const dueDateInServerLocalTime = Util.dateTimeInServerLocalTime(assignment.dueDate, true);
+
             return (
                 <li key={assignment.id} className="h-flex">
-                    <Link to={`/courses/${courseId}/assignments/${assignment.id}`} key={assignment.id} className="flex-grow-1">
-                        <span>Exercise {index + 1} {pastDueDate ? <Lock size={15} /> : ''}</span>
+                    <Link to={`/courses/${courseId}/assignments/${assignment.id}`} key={assignment.id}
+                          className="flex-grow-1">
+                        <span>Exercise {index + 1} {pastDueDate ? <Lock size={15}/> : ''}</span>
                         {label}
-                        <small><Clock size={12} /> Due date: {Util.timeFormatter(assignment.dueDate)}</small>
+                        <OverlayTrigger
+                            placement="top"
+                            overlay={
+                                <Tooltip id="tooltip-outdated">
+                                    {dueDateInServerLocalTime}
+                                </Tooltip>
+                            }
+                        >
+                            <small><Clock size={12}/> Due date: {Util.dateTimeFormatter(assignment.dueDate, true)}
+                            </small>
+                        </OverlayTrigger>
                     </Link>
                     <div>
                         {isAssistant &&
-                            <button className="style-btn"
-                            onClick={() => onAssignmentExportClick(assignment)}>Export Results</button>}
+                        <button className="style-btn"
+                                onClick={() => onAssignmentExportClick(assignment)}>Export Results</button>}
                         {result &&
-                            <div className="score-display">
-                                <span className="p-1"></span>
-                                <span className="style-btn ghost">Score:  {result.studentScore} / {result.maxScore}</span>
-                            </div>
+                        <div className="score-display">
+                            <span className="p-1"></span>
+                            <span className="style-btn ghost">Score: {result.studentScore} / {result.maxScore}</span>
+                        </div>
                         }
                     </div>
                 </li>

--- a/src/components/AssignmentList.js
+++ b/src/components/AssignmentList.js
@@ -1,16 +1,14 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import Util from '../utils/Util';
 import PropTypes from 'prop-types';
-import { Clock, Lock } from 'react-feather';
-import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { Lock } from 'react-feather';
+import { DueDateTime } from './DateTime';
 
 const AssignmentList = ({ courseId, assignments, isAssistant, onAssignmentExportClick, results }) => {
     const listItems = assignments.map((assignment, index) => {
             const pastDueDate = assignment.pastDueDate;
             const label = <><h5>{assignment.title}</h5></>;
             const result = results ? results.find(r => r.assignmentId === assignment.id) : undefined;
-            const dueDateInServerLocalTime = Util.dateTimeInServerLocalTime(assignment.dueDate, true);
 
             return (
                 <li key={assignment.id} className="h-flex">
@@ -18,17 +16,7 @@ const AssignmentList = ({ courseId, assignments, isAssistant, onAssignmentExport
                           className="flex-grow-1">
                         <span>Exercise {index + 1} {pastDueDate ? <Lock size={15}/> : ''}</span>
                         {label}
-                        <OverlayTrigger
-                            placement="top"
-                            overlay={
-                                <Tooltip id="tooltip-outdated">
-                                    {dueDateInServerLocalTime}
-                                </Tooltip>
-                            }
-                        >
-                            <small><Clock size={12}/> Due date: {Util.dateTimeFormatter(assignment.dueDate, true)}
-                            </small>
-                        </OverlayTrigger>
+                        <DueDateTime dueDate={assignment.dueDate}/>
                     </Link>
                     <div>
                         {isAssistant &&

--- a/src/components/DateTime.js
+++ b/src/components/DateTime.js
@@ -1,0 +1,59 @@
+import { Calendar, Clock } from 'react-feather';
+import Util from '../utils/Util';
+import React from 'react';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+
+const FromToDateTimeLabel = ({ fromDateTime, toDateTime, fromAppend = false, toAppend = false, ...props }) => (
+    <small {...props}>
+        <Calendar size={12}/> Open
+        from: <strong>{Util.dateTimeFormatter(fromDateTime, fromAppend)}</strong> -
+        to: <strong>{Util.dateTimeFormatter(toDateTime, toAppend)}</strong>
+    </small>
+);
+
+const FromToDateTime = ({ fromDateTime, toDateTime, fromAppend = false, toAppend = false }) => {
+    const isSameTZ = Util.isClientAndServerTZEquals();
+
+    if (!isSameTZ) {
+        const fromDateInServerLocalDateTime = Util.dateTimeInServerLocalTime(fromDateTime, false);
+        const toDateInServerLocalDateTime = Util.dateTimeInServerLocalTime(toDateTime, true);
+        return <OverlayTrigger
+            placement="top"
+            overlay={
+                <Tooltip id={'dateTimeTooltip'}>
+                    {fromDateInServerLocalDateTime + ' to ' + toDateInServerLocalDateTime}
+                </Tooltip>
+            }
+        >
+            <FromToDateTimeLabel fromDateTime={fromDateTime} toDateTime={toDateTime} fromAppend={fromAppend}
+                                 toAppend={toAppend}/>
+        </OverlayTrigger>;
+
+    }
+    return <FromToDateTimeLabel fromDateTime={fromDateTime} toDateTime={toDateTime} fromAppend={false}
+                                toAppend={false}/>;
+};
+
+const DueDateTime = ({ dueDate }) => {
+    const isSameTZ = Util.isClientAndServerTZEquals();
+    const dueDateLabel = <small><Clock size={12}/> Due date: {Util.dateTimeFormatter(dueDate, !isSameTZ)}</small>;
+    if (!isSameTZ) {
+        const dueDateInServerLocalTime = Util.dateTimeInServerLocalTime(dueDate, true);
+        return (
+            <OverlayTrigger
+                placement="top"
+                overlay={
+                    <Tooltip id="tooltip-outdated">
+                        {dueDateInServerLocalTime}
+                    </Tooltip>
+                }
+            >
+                {dueDateLabel}
+            </OverlayTrigger>
+        );
+    }
+
+    return dueDateLabel;
+};
+
+export { DueDateTime, FromToDateTime };

--- a/src/components/exercise/VersionList.js
+++ b/src/components/exercise/VersionList.js
@@ -1,10 +1,10 @@
 import SubmissionService from '../../utils/SubmissionService';
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 
 import equal from 'fast-deep-equal';
 import Util from '../../utils/Util';
-import {OverlayTrigger, Popover, Tabs, Tab, Modal, Alert} from 'react-bootstrap';
-import {Send, RotateCcw, X, Flag, Info} from 'react-feather';
+import { Alert, Modal, OverlayTrigger, Popover, Tab, Tabs } from 'react-bootstrap';
+import { Flag, Info, RotateCcw, Send, X } from 'react-feather';
 import PropTypes from 'prop-types';
 import Spinner from '../core/Spinner';
 import './VersionList.css';
@@ -17,10 +17,10 @@ class VersionList extends Component {
         submissionState: false,
         pastDueDate: false,
         submissionCount: {
-            submissionsRemaining: 0
+            submissionsRemaining: 0,
         },
         showModal: false,
-        currentTab: ''
+        currentTab: '',
     };
 
     onSubmit = () => {
@@ -34,26 +34,26 @@ class VersionList extends Component {
     confirmSubmit = () => {
         this.setShowModal(false);
         this.props.submit(true, this.resetSubmitButton);
-        this.setState({submissionState: true});
+        this.setState({ submissionState: true });
     };
 
     resetSubmitButton = () => {
-        this.setState({submissionState: false});
+        this.setState({ submissionState: false });
     };
 
     setCurrentTab = (key) => {
-        this.setState({currentTab: key});
+        this.setState({ currentTab: key });
     };
 
     componentDidMount = async () => {
-        const {exercise} = this.props;
+        const { exercise } = this.props;
 
         this.fetchSubmissions(exercise.id);
         this.setCurrentTab(this.props.isGraded ? 'submits' : 'testruns');
     };
 
     componentDidUpdate = async (prevProps) => {
-        const {exercise, selectedSubmissionId} = this.props;
+        const { exercise, selectedSubmissionId } = this.props;
         if (!equal(exercise, prevProps.exercise) || !equal(selectedSubmissionId, prevProps.selectedSubmissionId)) {
             this.fetchSubmissions(exercise.id);
             this.setCurrentTab(this.props.isGraded ? 'submits' : 'testruns');
@@ -61,14 +61,14 @@ class VersionList extends Component {
     };
 
     fetchSubmissions = async (exerciseId) => {
-        const {authorizationHeader} = this.props;
-        const {submissions, runs, submissionCount, pastDueDate} = await SubmissionService.getSubmissionList(exerciseId, authorizationHeader);
+        const { authorizationHeader } = this.props;
+        const { submissions, runs, submissionCount, pastDueDate } = await SubmissionService.getSubmissionList(exerciseId, authorizationHeader);
 
         this.setState({
             submissions,
             runs,
             pastDueDate,
-            submissionCount: submissionCount
+            submissionCount: submissionCount,
         });
     };
 
@@ -87,7 +87,7 @@ class VersionList extends Component {
                 Your Score: {result.score}
                 <br/>
                 Max Points: {result.maxScore}
-            </>
+            </>;
         }
 
         return (
@@ -115,7 +115,7 @@ class VersionList extends Component {
                      className={'submission-item ' + (outdated ? 'outdated' : '')}>
                     <strong>{title}{item.result && <span className="float-right">({item.result.score}P)</span>}</strong>
                     <br/>
-                    <small>{Util.dateTimeFormatter(item.timestamp, true)}</small>
+                    <small>{Util.dateTimeFormatter(item.timestamp, !Util.isClientAndServerTZEquals())}</small>
                     <br/>
                     <div className="two-box">
                         <button
@@ -141,11 +141,11 @@ class VersionList extends Component {
     }
 
     setShowModal = (show) => {
-        this.setState({showModal: show});
+        this.setState({ showModal: show });
     };
 
     lastSubmissionWarning() {
-        const {showModal} = this.state;
+        const { showModal } = this.state;
 
         return (
             <>
@@ -171,17 +171,17 @@ class VersionList extends Component {
     render() {
         const submissions = this.state.submissions || [];
         const runs = this.state.runs || [];
-        const {isCodeType, exercise} = this.props;
+        const { isCodeType, exercise } = this.props;
         const score = submissions.length && submissions[0] && submissions[0].result && submissions[0].result.score ? submissions[0].result.score : 0;
         const maxScore = exercise.maxScore ? exercise.maxScore : 1;
         const scorePercent = (score / maxScore * 100);
 
-        let scoreProgress = "low";
+        let scoreProgress = 'low';
 
         if (scorePercent > 75) {
-            scoreProgress = "full";
+            scoreProgress = 'full';
         } else if (scorePercent >= 50) {
-            scoreProgress = "mid";
+            scoreProgress = 'mid';
         }
 
 
@@ -212,8 +212,8 @@ class VersionList extends Component {
 
                 <span className="score-board">
                     <span>Score: <strong>{score}</strong> / {maxScore}</span>
-                    <span className={"score-bar " + scoreProgress} style={{
-                        width: scorePercent + "%"
+                    <span className={'score-bar ' + scoreProgress} style={{
+                        width: scorePercent + '%',
                     }}>
                     </span>
                 </span>
@@ -237,14 +237,14 @@ class VersionList extends Component {
                         <Tab eventKey="testruns" title="Testruns">
                             {runs.length === 0 ? <div className="py-3">No runs</div> : ''}
                             <ul className="style-list">
-                                {runs.slice(0, 6).map((item, index) => this.createSubmissionItem(item, (runs.length - index - 1), false),)}
+                                {runs.slice(0, 6).map((item, index) => this.createSubmissionItem(item, (runs.length - index - 1), false))}
                                 {templatePart}
                             </ul>
                         </Tab>
                         <Tab eventKey="submits" title="Submits">
                             {submissions.length === 0 ? <div className="py-3">No submissions</div> : ''}
                             <ul className="style-list">
-                                {submissions.map((item, index) => this.createSubmissionItem(item, (submissions.length - index - 1), true),)}
+                                {submissions.map((item, index) => this.createSubmissionItem(item, (submissions.length - index - 1), true))}
                                 {templatePart}
                             </ul>
                         </Tab>
@@ -254,7 +254,7 @@ class VersionList extends Component {
                         <h4>Submissions</h4>
                         <p>{submissions.length === 0 ? 'No submissions' : ''}</p>
                         <ul className="style-list">
-                            {submissions.map((item, index) => this.createSubmissionItem(item, (submissions.length - index - 1), true),)}
+                            {submissions.map((item, index) => this.createSubmissionItem(item, (submissions.length - index - 1), true))}
                             {templatePart}
                         </ul>
                     </>

--- a/src/components/exercise/VersionList.js
+++ b/src/components/exercise/VersionList.js
@@ -115,7 +115,7 @@ class VersionList extends Component {
                      className={'submission-item ' + (outdated ? 'outdated' : '')}>
                     <strong>{title}{item.result && <span className="float-right">({item.result.score}P)</span>}</strong>
                     <br/>
-                    <small>{Util.dateTimeFormatter(item.timestamp)}</small>
+                    <small>{Util.dateTimeFormatter(item.timestamp, true)}</small>
                     <br/>
                     <div className="two-box">
                         <button

--- a/src/components/exercise/VersionList.js
+++ b/src/components/exercise/VersionList.js
@@ -115,7 +115,7 @@ class VersionList extends Component {
                      className={'submission-item ' + (outdated ? 'outdated' : '')}>
                     <strong>{title}{item.result && <span className="float-right">({item.result.score}P)</span>}</strong>
                     <br/>
-                    <small>{Util.timeFormatter(item.timestamp)}</small>
+                    <small>{Util.dateTimeFormatter(item.timestamp)}</small>
                     <br/>
                     <div className="two-box">
                         <button

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,11 @@ import App from './App';
 import * as serviceWorker from './serviceWorker';
 import './index.css';
 import 'bootstrap/dist/css/bootstrap.css';
+import Util from './utils/Util';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+Util.fetchServerInfo();
+
+ReactDOM.render(<App/>, document.getElementById('root'));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/models/ServerInfo.js
+++ b/src/models/ServerInfo.js
@@ -1,0 +1,14 @@
+export default class ServerInfo {
+    constructor(json) {
+        this.zoneId = '';
+        this.utcTime = '';
+        this.offsetDateTime = '';
+        this.version = '';
+        Object.assign(this, json);
+    }
+
+    toString() {
+        return JSON.stringify(this);
+    }
+
+}

--- a/src/pages/Assignment.js
+++ b/src/pages/Assignment.js
@@ -1,12 +1,11 @@
 import React, { Component } from 'react';
 import CourseDataService from '../utils/CourseDataService';
 import ExerciseList from '../components/ExerciseList';
-import Util from '../utils/Util';
 import ResultService from '../utils/ResultService';
-import { Calendar } from 'react-feather';
 import { ErrorRedirect } from './ErrorPage';
 import { withBreadCrumbsAndAuth } from '../components/BreadCrumbProvider';
-import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { FromToDateTime } from '../components/DateTime';
+
 
 class Assignment extends Component {
 
@@ -61,26 +60,15 @@ class Assignment extends Component {
         }
 
         let gradedSubmissions = assignmentScore.gradedSubmissions ? assignmentScore.gradedSubmissions : [];
-        const publishDateInServerLocalDateTime = Util.dateTimeInServerLocalTime(assignment.publishDate, false);
-        const dueDateInServerLocalDateTime = Util.dateTimeInServerLocalTime(assignment.dueDate, true);
 
         return (
             <div className="container">
                 <div className="panel">
                     <div className="heading">
                         <h2>{assignment.title}</h2>
-                        <OverlayTrigger
-                            placement="top"
-                            overlay={
-                                <Tooltip>
-                                    {publishDateInServerLocalDateTime + ' to ' + dueDateInServerLocalDateTime}
-                                </Tooltip>
-                            }
-                        >
-                            <small><Calendar size={12}/> Open
-                                from: <strong>{Util.dateTimeFormatter(assignment.publishDate, false)}</strong> -
-                                to: <strong>{Util.dateTimeFormatter(assignment.dueDate, true)}</strong></small>
-                        </OverlayTrigger>
+                        <FromToDateTime fromDateTime={assignment.publishDate}
+                                        toDateTime={assignment.dueDate}
+                                        toAppend={true}/>
                     </div>
                     <p>{assignment.description}</p>
                     <br/>

--- a/src/pages/Assignment.js
+++ b/src/pages/Assignment.js
@@ -67,8 +67,8 @@ class Assignment extends Component {
                     <div className="heading">
                         <h2>{assignment.title}</h2>
                         <small><Calendar size={12}/> Open
-                            from: <strong>{Util.timeFormatter(assignment.publishDate)}</strong> -
-                            to: <strong>{Util.timeFormatter(assignment.dueDate)}</strong></small>
+                            from: <strong>{Util.dateTimeFormatter(assignment.publishDate)}</strong> -
+                            to: <strong>{Util.dateTimeFormatter(assignment.dueDate)}</strong></small>
                     </div>
                     <p>{assignment.description}</p>
                     <br/>

--- a/src/pages/Assignment.js
+++ b/src/pages/Assignment.js
@@ -6,6 +6,7 @@ import ResultService from '../utils/ResultService';
 import { Calendar } from 'react-feather';
 import { ErrorRedirect } from './ErrorPage';
 import { withBreadCrumbsAndAuth } from '../components/BreadCrumbProvider';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 class Assignment extends Component {
 
@@ -25,9 +26,9 @@ class Assignment extends Component {
         try {
             CourseDataService.getAssignment(courseId, assignmentId, context.authorizationHeader)
                 .then(result => {
-                        this.setState({ assignment: result, isLoadingAssignment: false })
+                        this.setState({ assignment: result, isLoadingAssignment: false });
                         this.props.crumbs.setBreadCrumbs(result.breadCrumbs);
-                    }
+                    },
                 )
                 .catch(err => {
                     console.debug('Error:', err.toString());
@@ -60,15 +61,26 @@ class Assignment extends Component {
         }
 
         let gradedSubmissions = assignmentScore.gradedSubmissions ? assignmentScore.gradedSubmissions : [];
+        const publishDateInServerLocalDateTime = Util.dateTimeInServerLocalTime(assignment.publishDate, false);
+        const dueDateInServerLocalDateTime = Util.dateTimeInServerLocalTime(assignment.dueDate, true);
 
         return (
             <div className="container">
                 <div className="panel">
                     <div className="heading">
                         <h2>{assignment.title}</h2>
-                        <small><Calendar size={12}/> Open
-                            from: <strong>{Util.dateTimeFormatter(assignment.publishDate)}</strong> -
-                            to: <strong>{Util.dateTimeFormatter(assignment.dueDate)}</strong></small>
+                        <OverlayTrigger
+                            placement="top"
+                            overlay={
+                                <Tooltip>
+                                    {publishDateInServerLocalDateTime + ' to ' + dueDateInServerLocalDateTime}
+                                </Tooltip>
+                            }
+                        >
+                            <small><Calendar size={12}/> Open
+                                from: <strong>{Util.dateTimeFormatter(assignment.publishDate, false)}</strong> -
+                                to: <strong>{Util.dateTimeFormatter(assignment.dueDate, true)}</strong></small>
+                        </OverlayTrigger>
                     </div>
                     <p>{assignment.description}</p>
                     <br/>

--- a/src/pages/Course.js
+++ b/src/pages/Course.js
@@ -77,8 +77,8 @@ class Course extends Component {
                 <div className="panel">
                     <div className="heading">
                         <h2>{course.title}</h2>
-                        <small><Calendar size={12} /> Open from: <strong>{Util.timeFormatter(course.startDate)}</strong> -
-                            to: <strong>{Util.timeFormatter(course.endDate)}</strong></small>
+                        <small><Calendar size={12} /> Open from: <strong>{Util.dateTimeFormatter(course.startDate)}</strong> -
+                            to: <strong>{Util.dateTimeFormatter(course.endDate)}</strong></small>
                     </div>
                     <p>{course.description}</p>
                     <br/>

--- a/src/pages/Course.js
+++ b/src/pages/Course.js
@@ -1,13 +1,11 @@
 import React, { Component } from 'react';
 import CourseDataService from '../utils/CourseDataService';
 import AssignmentList from '../components/AssignmentList';
-import Util from '../utils/Util';
 import AdminService from '../utils/AdminService';
 import { ExportModal } from '../components/course/AssistantExport';
 import ResultService from '../utils/ResultService';
-import { Calendar } from 'react-feather';
 import { withBreadCrumbsAndAuth } from '../components/BreadCrumbProvider';
-import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { FromToDateTime } from '../components/DateTime';
 
 class Course extends Component {
 
@@ -71,33 +69,23 @@ class Course extends Component {
             return null;
         }
 
-        const isCourseAssistant = this.props.context.isCourseAssistant(course.id);
-        const startDateInServerLocalDateTime = Util.dateTimeInServerLocalTime(course.startDate, false);
-        const endDateInServerLocalDateTime = Util.dateTimeInServerLocalTime(course.endDate, true);
+        const { id: courseId, startDate, endDate, assignments, title, description } = course;
+
+        const isCourseAssistant = this.props.context.isCourseAssistant(courseId);
 
         return (
             <div className="container">
                 <div className="panel">
                     <div className="heading">
-                        <h2>{course.title}</h2>
-                        <OverlayTrigger
-                            placement="top"
-                            overlay={
-                                <Tooltip>
-                                    {startDateInServerLocalDateTime + ' to ' + endDateInServerLocalDateTime}
-                                </Tooltip>
-                            }
-                        >
-                            <small><Calendar size={12}/> Open
-                                from: <strong>{Util.dateTimeFormatter(course.startDate, false)}</strong> -
-                                to: <strong>{Util.dateTimeFormatter(course.endDate, true)}</strong></small>
-                        </OverlayTrigger>
+                        <h2>{title}</h2>
+                        <FromToDateTime fromDateTime={startDate} toDateTime={endDate}
+                                        toAppend={true}/>
                     </div>
-                    <p>{course.description}</p>
+                    <p>{description}</p>
                     <br/>
                     <br/>
                     <div>
-                        <AssignmentList courseId={course.id} assignments={course.assignments}
+                        <AssignmentList courseId={courseId} assignments={assignments}
                                         isAssistant={isCourseAssistant}
                                         onAssignmentExportClick={this.onAssignmentExportClick}
                                         results={courseResults}
@@ -105,7 +93,7 @@ class Course extends Component {
                     </div>
 
                     {assignmentExport && <ExportModal assignmentTitle={modalAssignmentTitle}
-                                                      courseId={this.state.course.id}
+                                                      courseId={courseId}
                                                       assignmentExport={assignmentExport}
                                                       showModal={showModal && !!assignmentExport}
                                                       authorization={this.props.context.authorizationHeader}

--- a/src/pages/Course.js
+++ b/src/pages/Course.js
@@ -4,9 +4,10 @@ import AssignmentList from '../components/AssignmentList';
 import Util from '../utils/Util';
 import AdminService from '../utils/AdminService';
 import { ExportModal } from '../components/course/AssistantExport';
-import ResultService from "../utils/ResultService";
+import ResultService from '../utils/ResultService';
 import { Calendar } from 'react-feather';
 import { withBreadCrumbsAndAuth } from '../components/BreadCrumbProvider';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 class Course extends Component {
 
@@ -28,16 +29,16 @@ class Course extends Component {
         CourseDataService.getCourses(context.authorizationHeader)
             .then(result => {
                 const course = result.find(c => c.id === courseId);
-                this.setState({ course:  course});
+                this.setState({ course: course });
                 this.props.crumbs.setBreadCrumbs(course.breadCrumbs);
             })
             .catch(err => {
                 console.debug('Error:', err.toString());
             });
 
-         ResultService.getCourseResults(courseId, context.authorizationHeader)
-            .then(result => this.setState({courseResults: result}))
-           //  .then(result => console.warn(result))
+        ResultService.getCourseResults(courseId, context.authorizationHeader)
+            .then(result => this.setState({ courseResults: result }))
+            //  .then(result => console.warn(result))
             .catch(err => {
                 console.debug('Error:', err.toString());
             });
@@ -71,14 +72,26 @@ class Course extends Component {
         }
 
         const isCourseAssistant = this.props.context.isCourseAssistant(course.id);
+        const startDateInServerLocalDateTime = Util.dateTimeInServerLocalTime(course.startDate, false);
+        const endDateInServerLocalDateTime = Util.dateTimeInServerLocalTime(course.endDate, true);
 
         return (
             <div className="container">
                 <div className="panel">
                     <div className="heading">
                         <h2>{course.title}</h2>
-                        <small><Calendar size={12} /> Open from: <strong>{Util.dateTimeFormatter(course.startDate)}</strong> -
-                            to: <strong>{Util.dateTimeFormatter(course.endDate)}</strong></small>
+                        <OverlayTrigger
+                            placement="top"
+                            overlay={
+                                <Tooltip>
+                                    {startDateInServerLocalDateTime + ' to ' + endDateInServerLocalDateTime}
+                                </Tooltip>
+                            }
+                        >
+                            <small><Calendar size={12}/> Open
+                                from: <strong>{Util.dateTimeFormatter(course.startDate, false)}</strong> -
+                                to: <strong>{Util.dateTimeFormatter(course.endDate, true)}</strong></small>
+                        </OverlayTrigger>
                     </div>
                     <p>{course.description}</p>
                     <br/>
@@ -93,10 +106,10 @@ class Course extends Component {
 
                     {assignmentExport && <ExportModal assignmentTitle={modalAssignmentTitle}
                                                       courseId={this.state.course.id}
-                                                    assignmentExport={assignmentExport}
-                                                    showModal={showModal && !!assignmentExport}
-                                                    authorization={this.props.context.authorizationHeader}
-                                                    handleClose={this.closeModal}/>
+                                                      assignmentExport={assignmentExport}
+                                                      showModal={showModal && !!assignmentExport}
+                                                      authorization={this.props.context.authorizationHeader}
+                                                      handleClose={this.closeModal}/>
                     }
                 </div>
             </div>

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -36,6 +36,10 @@ class Util {
         return new ServerInfo(JSON.parse(localStorage.getItem('serverInfo')));
     }
 
+    static isClientAndServerTZEquals() {
+        return this.clientTimezone() === this.serverInfo().zoneId;
+    }
+
     /**
      * Converts a dateTime to server local time
      * @param dateTime

--- a/src/utils/Util.js
+++ b/src/utils/Util.js
@@ -1,24 +1,90 @@
+import ServerInfo from '../models/ServerInfo';
 
-class Util{
-    static timeFormatter(time){
-        var t = new Date(time);
-        return t.getDate() + "." + (t.getMonth() + 1) + "." + t.getFullYear() + " " + this.paddZero(t.getHours()) + ":" + this.paddZero(t.getMinutes());
-        //return ret.setSeconds(0,0).toLocaleString().replace(",", "");
+class Util {
+
+    /**
+     * Formats and converts a dateTime using the given zoneId.
+     * If no zoneId is given, then uses the client system's configured zoneId.
+     * @param dateTime
+     * @param zoneId
+     * @param appendTZ whether to append the timezone to the formatted string
+     * @returns {string}
+     */
+    static dateTimeFormatter(dateTime, appendTZ, zoneId) {
+        zoneId = zoneId || this.clientTimezone();
+        const options = {
+            year: 'numeric', month: '2-digit', day: '2-digit',
+            hour: '2-digit', minute: '2-digit',
+            timeZone: zoneId ? zoneId : this.clientTimezone(),
+        };
+
+        const formatter = new Intl.DateTimeFormat('de-CH', options);
+        const startingDate = new Date(dateTime);
+
+        const formattedDate = formatter.format(startingDate);
+        if (appendTZ) {
+            return formattedDate + ' ' + zoneId;
+        }
+        return formattedDate;
     }
 
-    static paddZero(n){
-        if(n <= 9){
-          return "0" + n;
-        }
-        return n
-      }
+    static clientTimezone() {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone;
+    }
+
+    static serverInfo() {
+        return new ServerInfo(JSON.parse(localStorage.getItem('serverInfo')));
+    }
+
+    /**
+     * Converts a dateTime to server local time
+     * @param dateTime
+     * @param appendTZ whether to append the timezone to the formatted string
+     * @returns {string}
+     */
+    static dateTimeInServerLocalTime(dateTime, appendTZ) {
+        const zoneId = Util.serverInfo().zoneId;
+        return this.dateTimeFormatter(dateTime, appendTZ, zoneId);
+    }
+
+    static timeFormatter(date, zoneId) {
+        const options = {
+            year: 'numeric', month: '2-digit', day: '2-digit',
+            hour: '2-digit', minute: '2-digit',
+            timeZone: zoneId,
+        };
+        const formatter = new Intl.DateTimeFormat('de-CH', options);
+        const startingDate = new Date(date);
+
+        return formatter.format(startingDate) + ' ' + zoneId;
+    }
+
+    static fetchServerInfo() {
+        fetch('/api/info').then(response => {
+            if (response.ok) {
+                return response.json();
+            } else {
+                throw new Error(response.statusText);
+            }
+        }).then(body => {
+            console.debug('Server information', body);
+            const serverInfo = new ServerInfo(body);
+            localStorage.setItem('serverInfo', serverInfo.toString());
+        }).catch(error => {
+            console.error('Failed to get response from server', error);
+        });
+    }
 
     static humanize(str) {
         return str
             .replace(/^[\s_]+|[\s_]+$/g, '')
             .replace(/[_\s]+/g, ' ')
-            .replace(/([a-z])([A-Z])/, function(m) { return m[0] + " " + m[1]; })
-            .replace(/^[a-z]/, function(m) { return m.toUpperCase(); });
+            .replace(/([a-z])([A-Z])/, function(m) {
+                return m[0] + ' ' + m[1];
+            })
+            .replace(/^[a-z]/, function(m) {
+                return m.toUpperCase();
+            });
     }
 
     static getIsDarkFromLocalStorage() {
@@ -39,23 +105,23 @@ class Util{
 
     static MEDIA_TYPE_MAP = {
         // Code
-        'py':   'code',
-        'js':   'code',
-        'css':  'code',
+        'py': 'code',
+        'js': 'code',
+        'css': 'code',
         'json': 'code',
-        'md':   'code',
-        'c':    'code',
-        'cpp':  'code',
-        'h':    'code',
+        'md': 'code',
+        'c': 'code',
+        'cpp': 'code',
+        'h': 'code',
         'java': 'code',
-        'txt':  'code',
+        'txt': 'code',
 
         // Image
-        'png':  'img',
-        'jpg':  'img',
+        'png': 'img',
+        'jpg': 'img',
         'jpeg': 'img',
-        'gif':  'img',
-        'svg':  'img',
+        'gif': 'img',
+        'svg': 'img',
     };
 }
 


### PR DESCRIPTION
If the client and server timezone (TZ) are different:
- display user's configured TZ next to the local date time
- on hover show overlay showing date time in server local date time

If the client and server TZ are the same:
- Don't show user's TZ next to local date time
- no hover overlay is displayed
-> Basically the same as before


![Screenshot 2019-10-11 01 40 10](https://user-images.githubusercontent.com/10435742/66614290-ba1d9c00-ebc8-11e9-87d4-e467cf99fe76.png)
![Screenshot 2019-10-11 01 40 14](https://user-images.githubusercontent.com/10435742/66614292-ba1d9c00-ebc8-11e9-9216-819ce5e08534.png)
![Screenshot 2019-10-11 01 40 20](https://user-images.githubusercontent.com/10435742/66614294-ba1d9c00-ebc8-11e9-92c0-70deeb3feb81.png)

Closes https://github.com/mp-access/Backend/issues/345